### PR TITLE
Switch confirmation email subject

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -313,7 +313,7 @@ class auth_plugin_emailadmin extends auth_plugin_base {
 
             $subject = get_string_manager()->get_string('auth_emailadminconfirmationsubject',
                                                         'auth_emailadmin',
-                                                        format_string($site->fullname),
+                                                        $data,
                                                         $use_lang);
 
             $message     = get_string_manager()->get_string('auth_emailadminconfirmation', 'auth_emailadmin', $data, $use_lang);
@@ -346,7 +346,7 @@ class auth_plugin_emailadmin extends auth_plugin_base {
 
                     $subject = get_string_manager()->get_string('auth_emailadminconfirmationsubject',
                                                                 'auth_emailadmin',
-                                                                format_string($site->fullname),
+                                                                $data,
                                                                 $use_lang);
 
                     $message     = get_string_manager()->get_string('auth_emailadminconfirmation', 'auth_emailadmin', $data, $use_lang);


### PR DESCRIPTION
Allow for other variables in account confirmation email subject by calling $data instead of only $site->fullname.